### PR TITLE
Add analytics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ module.exports = {
 | `accessToken`            | `string` | Your Contentful content delivery API access token          | `true`   |
 | `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
 | `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
-| `googleAnalyticsOptions` | `object` | Your Google Analytics options                              | `false`  |
+| `googleAnalytics` | `object` | Your Google Analytics options                              | `false`  |
 
 Create your Contentful space, generate all the needed api keys and fill them in.
 
-📊 Google Analytics is an optional feature if you really want to include analytics scripts in your site, you **must** pass the `trackingId` key to the `googleAnalyticsOptions` object.
+📊 Google Analytics is an optional feature if you really want to include analytics scripts in your site, you **must** pass the `trackingId` key to the `googleAnalytics` object.
 
 Check all the options available at the gatsby-plugin-google-analytics [documentation](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use).
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ module.exports = {
         accessToken: '',
         managementToken: '',
         environmentId: '',
-        mailTo: 'become@jobs.com',
-        googleAnalyticsOptions: {...}
       },
     },
   ],
@@ -50,13 +48,13 @@ module.exports = {
 | `accessToken`            | `string` | Your Contentful content delivery API access token          | `true`   |
 | `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
 | `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
-| `mailTo`                 | `string` | The e-mail address for people apply                        | `true`   |
 | `googleAnalyticsOptions` | `object` | Your Google Analytics options                              | `false`  |
 
 Create your Contentful space, generate all the needed api keys and fill them in.
 
-📊 :Google Analytics is optional, however by default this is placed on body and you **must** pass the key `trackingId` to have the GA script included.
-All options are available on this [link](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use).
+📊 Google Analytics is an optional feature if you really want to include analytics scripts in your site, you **must** pass the `trackingId` key to the `googleAnalyticsOptions` object.
+
+Check all the options available at the gatsby-plugin-google-analytics [documentation](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use).
 
 ## 🔥 Running
 

--- a/README.md
+++ b/README.md
@@ -34,22 +34,29 @@ module.exports = {
         accessToken: '',
         managementToken: '',
         environmentId: '',
+        mailTo: 'become@jobs.com',
+        googleAnalyticsOptions: {...}
       },
     },
   ],
 }
 ```
 
-| Option Name       | Type     | Description                                                | Required |
-| :---------------- | :------- | :--------------------------------------------------------- | :------- |
-| `basePath`        | `string` | The base path where your site will live. (e.g. `/careers`) | `false`  |
-| `title`           | `string` | The main title used in the header                          | `false`  |
-| `spaceId`         | `string` | Your Contentful space ID                                   | `true`   |
-| `accessToken`     | `string` | Your Contentful content delivery API access token          | `true`   |
-| `managementToken` | `string` | Your Contentful personal access                            | `true`   |
-| `environmentId`   | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
+| Option Name              | Type     | Description                                                | Required |
+| :----------------------- | :------- | :--------------------------------------------------------- | :------- |
+| `basePath`               | `string` | The base path where your site will live. (e.g. `/careers`) | `false`  |
+| `title`                  | `string` | The main title used in the header                          | `false`  |
+| `spaceId`                | `string` | Your Contentful space ID                                   | `true`   |
+| `accessToken`            | `string` | Your Contentful content delivery API access token          | `true`   |
+| `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
+| `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
+| `mailTo`                 | `string` | The e-mail address for people apply                        | `true`   |
+| `googleAnalyticsOptions` | `object` | Your Google Analytics options                              | `false`  |
 
 Create your Contentful space, generate all the needed api keys and fill them in.
+
+📊 :Google Analytics is optional, however by default this is placed on body and you **must** pass the key `trackingId` to have the GA script included.
+All options are available on this [link](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use).
 
 ## 🔥 Running
 

--- a/packages/gatsby-theme-careers/README.md
+++ b/packages/gatsby-theme-careers/README.md
@@ -34,22 +34,27 @@ module.exports = {
         accessToken: '',
         managementToken: '',
         environmentId: '',
+        googleAnalyticsOptions: {...}
       },
     },
   ],
 }
 ```
 
-| Option Name       | Type     | Description                                                | Required |
-| :---------------- | :------- | :--------------------------------------------------------- | :------- |
-| `basePath`        | `string` | The base path where your site will live. (e.g. `/careers`) | `false`  |
-| `title`           | `string` | The main title used in the header                          | `false`  |
-| `spaceId`         | `string` | Your Contentful space ID                                   | `true`   |
-| `accessToken`     | `string` | Your Contentful content delivery API access token          | `true`   |
-| `managementToken` | `string` | Your Contentful personal access                            | `true`   |
-| `environmentId`   | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
+| Option Name              | Type     | Description                                                | Required |
+| :----------------------- | :------- | :--------------------------------------------------------- | :------- |
+| `basePath`               | `string` | The base path where your site will live. (e.g. `/careers`) | `false`  |
+| `title`                  | `string` | The main title used in the header                          | `false`  |
+| `spaceId`                | `string` | Your Contentful space ID                                   | `true`   |
+| `accessToken`            | `string` | Your Contentful content delivery API access token          | `true`   |
+| `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
+| `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
+| `googleAnalyticsOptions` | `object` | Your Google Analytics options                              | `false`  |
 
 Create your Contentful space, generate all the needed api keys and fill them in.
+
+📊 :Google Analytics is optional, however by default this is placed on body and you **must** pass the key `trackingId` to have the GA script included.
+All options are available on this [link](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use).
 
 ## 🔥 Running
 

--- a/packages/gatsby-theme-careers/README.md
+++ b/packages/gatsby-theme-careers/README.md
@@ -48,11 +48,11 @@ module.exports = {
 | `accessToken`            | `string` | Your Contentful content delivery API access token          | `true`   |
 | `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
 | `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
-| `googleAnalyticsOptions` | `object` | Your Google Analytics options                              | `false`  |
+| `googleAnalytics` | `object` | Your Google Analytics options                              | `false`  |
 
 Create your Contentful space, generate all the needed api keys and fill them in.
 
-📊 Google Analytics is an optional feature if you really want to include analytics scripts in your site, you **must** pass the `trackingId` key to the `googleAnalyticsOptions` object.
+📊 Google Analytics is an optional feature if you really want to include analytics scripts in your site, you **must** pass the `trackingId` key to the `googleAnalytics` object.
 
 Check all the options available at the gatsby-plugin-google-analytics [documentation](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use).
 

--- a/packages/gatsby-theme-careers/README.md
+++ b/packages/gatsby-theme-careers/README.md
@@ -34,8 +34,6 @@ module.exports = {
         accessToken: '',
         managementToken: '',
         environmentId: '',
-        mailTo: 'become@jobs.com',
-        googleAnalyticsOptions: {...}
       },
     },
   ],
@@ -50,13 +48,13 @@ module.exports = {
 | `accessToken`            | `string` | Your Contentful content delivery API access token          | `true`   |
 | `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
 | `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
-| `mailTo`                 | `string` | The e-mail address for people apply                        | `true`   |
 | `googleAnalyticsOptions` | `object` | Your Google Analytics options                              | `false`  |
 
 Create your Contentful space, generate all the needed api keys and fill them in.
 
-📊 :Google Analytics is optional, however by default this is placed on body and you **must** pass the key `trackingId` to have the GA script included.
-All options are available on this [link](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use).
+📊 Google Analytics is an optional feature if you really want to include analytics scripts in your site, you **must** pass the `trackingId` key to the `googleAnalyticsOptions` object.
+
+Check all the options available at the gatsby-plugin-google-analytics [documentation](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use).
 
 ## 🔥 Running
 

--- a/packages/gatsby-theme-careers/README.md
+++ b/packages/gatsby-theme-careers/README.md
@@ -34,6 +34,7 @@ module.exports = {
         accessToken: '',
         managementToken: '',
         environmentId: '',
+        mailTo: 'become@jobs.com',
         googleAnalyticsOptions: {...}
       },
     },
@@ -49,6 +50,7 @@ module.exports = {
 | `accessToken`            | `string` | Your Contentful content delivery API access token          | `true`   |
 | `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
 | `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
+| `mailTo`                 | `string` | The e-mail address for people apply                        | `true`   |
 | `googleAnalyticsOptions` | `object` | Your Google Analytics options                              | `false`  |
 
 Create your Contentful space, generate all the needed api keys and fill them in.

--- a/packages/gatsby-theme-careers/gatsby-config.js
+++ b/packages/gatsby-theme-careers/gatsby-config.js
@@ -4,12 +4,10 @@ module.exports = ({
   spaceId,
   accessToken,
   googleAnalyticsOptions,
-  mailTo,
 } = {}) => ({
   siteMetadata: {
     title,
     basePath,
-    mailTo,
   },
   plugins: [
     'gatsby-plugin-styled-components',
@@ -22,11 +20,9 @@ module.exports = ({
       },
     },
     {
-      resolve: `gatsby-plugin-google-analytics`,
+      resolve: 'gatsby-plugin-google-analytics',
       options: {
-        // Defines where to place the tracking script - `true` in the head and `false` in the body
         head: false,
-        //All options available https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use
         ...googleAnalyticsOptions,
       },
     },

--- a/packages/gatsby-theme-careers/gatsby-config.js
+++ b/packages/gatsby-theme-careers/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = ({
   title = 'Gatsby Theme Careers',
   spaceId,
   accessToken,
-  googleAnalyticsOptions,
+  googleAnalytics,
 } = {}) => ({
   siteMetadata: {
     title,
@@ -23,7 +23,7 @@ module.exports = ({
       resolve: 'gatsby-plugin-google-analytics',
       options: {
         head: false,
-        ...googleAnalyticsOptions,
+        ...googleAnalytics,
       },
     },
   ],

--- a/packages/gatsby-theme-careers/gatsby-config.js
+++ b/packages/gatsby-theme-careers/gatsby-config.js
@@ -4,10 +4,12 @@ module.exports = ({
   spaceId,
   accessToken,
   googleAnalyticsOptions,
+  mailTo,
 } = {}) => ({
   siteMetadata: {
     title,
     basePath,
+    mailTo,
   },
   plugins: [
     'gatsby-plugin-styled-components',

--- a/packages/gatsby-theme-careers/gatsby-config.js
+++ b/packages/gatsby-theme-careers/gatsby-config.js
@@ -3,6 +3,7 @@ module.exports = ({
   title = 'Gatsby Theme Careers',
   spaceId,
   accessToken,
+  googleAnalyticsOptions,
 } = {}) => ({
   siteMetadata: {
     title,
@@ -16,6 +17,15 @@ module.exports = ({
         downloadLocal: true,
         spaceId,
         accessToken,
+      },
+    },
+    {
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        // Defines where to place the tracking script - `true` in the head and `false` in the body
+        head: false,
+        //All options available https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use
+        ...googleAnalyticsOptions,
       },
     },
   ],

--- a/packages/gatsby-theme-careers/package.json
+++ b/packages/gatsby-theme-careers/package.json
@@ -16,6 +16,7 @@
     "babel-plugin-styled-components": "^1.10.6",
     "contentful-migration": "^1.0.6",
     "flokit": "^1.0.0-alpha.1",
+    "gatsby-plugin-google-analytics": "^2.1.29",
     "gatsby-plugin-styled-components": "^3.1.14",
     "gatsby-source-contentful": "^2.1.64",
     "styled-components": "^4.4.1"

--- a/packages/gatsby-theme-careers/src/components/Job.js
+++ b/packages/gatsby-theme-careers/src/components/Job.js
@@ -4,33 +4,23 @@ import { Box, Heading } from 'flokit'
 import Layout from './Layout'
 import TagList from './TagList'
 import Button from './Button'
-import useSiteMetadata from '../hooks/useSiteMetadata'
 
-const Job = ({ job }) => {
-  const { mailTo } = useSiteMetadata()
-  const mail = `mailto:${mailTo}?subject${job.title}`
+const Job = ({ job }) => (
+  <Layout>
+    <Box as='header' width={1} marginBottom='5' paddingRight='3'>
+      <Heading as='h1' marginBottom='3' fontSize='8' fontWeight='4'>
+        {job.title}
+      </Heading>
 
-  return (
-    <Layout>
-      <Box as='header' width={1} marginBottom='5' paddingRight='3'>
-        <Heading as='h1' marginBottom='3' fontSize='8' fontWeight='4'>
-          {job.title}
-        </Heading>
+      <TagList tags={job.tags} />
+    </Box>
 
-        <TagList tags={job.tags} />
-      </Box>
+    <article>
+      {job.body && documentToReactComponents(job.body.json)}
 
-      <article>
-        {job.body && documentToReactComponents(job.body.json)}
-
-        {mailTo && (
-          <Button as='a' title='Send an email' href={mail} marginTop='5'>
-            Apply
-          </Button>
-        )}
-      </article>
-    </Layout>
-  )
-}
+      <Button marginTop='5'>Apply</Button>
+    </article>
+  </Layout>
+)
 
 export default Job

--- a/packages/gatsby-theme-careers/src/components/Job.js
+++ b/packages/gatsby-theme-careers/src/components/Job.js
@@ -4,23 +4,33 @@ import { Box, Heading } from 'flokit'
 import Layout from './Layout'
 import TagList from './TagList'
 import Button from './Button'
+import useSiteMetadata from '../hooks/useSiteMetadata'
 
-const Job = ({ job }) => (
-  <Layout>
-    <Box as='header' width={1} marginBottom='5' paddingRight='3'>
-      <Heading as='h1' marginBottom='3' fontSize='8' fontWeight='4'>
-        {job.title}
-      </Heading>
+const Job = ({ job }) => {
+  const { mailTo } = useSiteMetadata()
+  const mail = `mailto:${mailTo}?subject${job.title}`
 
-      <TagList tags={job.tags} />
-    </Box>
+  return (
+    <Layout>
+      <Box as='header' width={1} marginBottom='5' paddingRight='3'>
+        <Heading as='h1' marginBottom='3' fontSize='8' fontWeight='4'>
+          {job.title}
+        </Heading>
 
-    <article>
-      {job.body && documentToReactComponents(job.body.json)}
+        <TagList tags={job.tags} />
+      </Box>
 
-      <Button marginTop='5'>Apply</Button>
-    </article>
-  </Layout>
-)
+      <article>
+        {job.body && documentToReactComponents(job.body.json)}
+
+        {mailTo && (
+          <Button as='a' title='Send an email' href={mail} marginTop='5'>
+            Apply
+          </Button>
+        )}
+      </article>
+    </Layout>
+  )
+}
 
 export default Job

--- a/yarn.lock
+++ b/yarn.lock
@@ -5397,6 +5397,13 @@ gatsby-page-utils@^0.0.32:
     lodash "^4.17.15"
     micromatch "^3.1.10"
 
+gatsby-plugin-google-analytics@^2.1.29:
+  version "2.1.29"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.1.29.tgz#d24caabf2a89abd95f1620434ff784088bac38f2"
+  integrity sha512-vRMmXyam7LUwD+xdWCLQTbe5pT8FOX3vcIJdwckY/c3x3/GFIkx9bRJ1/N8z9x9dAci3g0HoTQZ6BkcqcNhzkA==
+  dependencies:
+    "@babel/runtime" "^7.7.4"
+
 gatsby-plugin-page-creator@^2.1.32:
   version "2.1.32"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.32.tgz#696fc390ff4abb5daede05a7b76c0516c2a8eec8"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Is related to the issue #29 
Adds Google Analytics plugin to the theme.

#### Where should the reviewer start?

Creating the example as mentioned below.

#### How should this be manually tested?

1. You should create an example project using the theme.
2. Add a Tracking Id in the config file. You can use a fake one just to check if the script is included. In case you want a fully working version, a valid tracking should be getting from GA admin.

#### Any background context you want to provide?

The plugin used is the [gatsby-plugin-google-analytics](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics)