### PR TITLE
Add mailTo as config to apply button

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,22 @@ module.exports = {
         accessToken: '',
         managementToken: '',
         environmentId: '',
+        mailTo: 'become@jobs.com'
       },
     },
   ],
 }
 ```
 
-| Option Name       | Type     | Description                                                | Required |
-| :---------------- | :------- | :--------------------------------------------------------- | :------- |
-| `basePath`        | `string` | The base path where your site will live. (e.g. `/careers`) | `false`  |
-| `title`           | `string` | The main title used in the header                          | `false`  |
-| `spaceId`         | `string` | Your Contentful space ID                                   | `true`   |
-| `accessToken`     | `string` | Your Contentful content delivery API access token          | `true`   |
-| `managementToken` | `string` | Your Contentful personal access                            | `true`   |
-| `environmentId`   | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
+| Option Name              | Type     | Description                                                | Required |
+| :----------------------- | :------- | :--------------------------------------------------------- | :------- |
+| `basePath`               | `string` | The base path where your site will live. (e.g. `/careers`) | `false`  |
+| `title`                  | `string` | The main title used in the header                          | `false`  |
+| `spaceId`                | `string` | Your Contentful space ID                                   | `true`   |
+| `accessToken`            | `string` | Your Contentful content delivery API access token          | `true`   |
+| `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
+| `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
+| `mailTo`                 | `string` | The e-mail address for people apply                        | `true`   |
 
 Create your Contentful space, generate all the needed api keys and fill them in.
 

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -5,12 +5,12 @@ module.exports = {
     {
       resolve: 'gatsby-theme-careers',
       options: {
+        mailTo: 'become@jobs.com',
         spaceId: process.env.CONTENTFUL_SPACE_ID,
         accessToken: process.env.CONTENTFUL_CONTENT_API_ACCESS_TOKEN,
         managementToken: process.env.CONTENTFUL_CONTENT_MANAGEMENT_TOKEN,
         environmentId: process.env.CONTENTFUL_ENVIRONMENT_ID,
-        downloadLocal: true,
-        mailTo: 'become@jobs.com'
+        downloadLocal: true
       },
     },
   ],

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -10,6 +10,7 @@ module.exports = {
         managementToken: process.env.CONTENTFUL_CONTENT_MANAGEMENT_TOKEN,
         environmentId: process.env.CONTENTFUL_ENVIRONMENT_ID,
         downloadLocal: true,
+        mailTo: 'become@jobs.com'
       },
     },
   ],

--- a/packages/gatsby-theme-careers/README.md
+++ b/packages/gatsby-theme-careers/README.md
@@ -34,20 +34,24 @@ module.exports = {
         accessToken: '',
         managementToken: '',
         environmentId: '',
+        mailTo: 'become@jobs.com',
+        googleAnalyticsOptions: {...}
       },
     },
   ],
 }
 ```
 
-| Option Name       | Type     | Description                                                | Required |
-| :---------------- | :------- | :--------------------------------------------------------- | :------- |
-| `basePath`        | `string` | The base path where your site will live. (e.g. `/careers`) | `false`  |
-| `title`           | `string` | The main title used in the header                          | `false`  |
-| `spaceId`         | `string` | Your Contentful space ID                                   | `true`   |
-| `accessToken`     | `string` | Your Contentful content delivery API access token          | `true`   |
-| `managementToken` | `string` | Your Contentful personal access                            | `true`   |
-| `environmentId`   | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
+| Option Name              | Type     | Description                                                | Required |
+| :----------------------- | :------- | :--------------------------------------------------------- | :------- |
+| `basePath`               | `string` | The base path where your site will live. (e.g. `/careers`) | `false`  |
+| `title`                  | `string` | The main title used in the header                          | `false`  |
+| `spaceId`                | `string` | Your Contentful space ID                                   | `true`   |
+| `accessToken`            | `string` | Your Contentful content delivery API access token          | `true`   |
+| `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
+| `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
+| `mailTo`                 | `string` | The e-mail address for people apply                        | `true`   |
+| `googleAnalyticsOptions` | `object` | Your Google Analytics options                              | `false`  |
 
 Create your Contentful space, generate all the needed api keys and fill them in.
 

--- a/packages/gatsby-theme-careers/README.md
+++ b/packages/gatsby-theme-careers/README.md
@@ -35,7 +35,6 @@ module.exports = {
         managementToken: '',
         environmentId: '',
         mailTo: 'become@jobs.com',
-        googleAnalyticsOptions: {...}
       },
     },
   ],
@@ -51,7 +50,6 @@ module.exports = {
 | `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
 | `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
 | `mailTo`                 | `string` | The e-mail address for people apply                        | `true`   |
-| `googleAnalyticsOptions` | `object` | Your Google Analytics options                              | `false`  |
 
 Create your Contentful space, generate all the needed api keys and fill them in.
 

--- a/packages/gatsby-theme-careers/README.md
+++ b/packages/gatsby-theme-careers/README.md
@@ -30,11 +30,11 @@ module.exports = {
     {
       resolve: 'gatsby-theme-careers',
       options: {
+        mailTo: 'become@jobs.com',
         spaceId: '',
         accessToken: '',
         managementToken: '',
         environmentId: '',
-        mailTo: 'become@jobs.com',
       },
     },
   ],
@@ -45,11 +45,11 @@ module.exports = {
 | :----------------------- | :------- | :--------------------------------------------------------- | :------- |
 | `basePath`               | `string` | The base path where your site will live. (e.g. `/careers`) | `false`  |
 | `title`                  | `string` | The main title used in the header                          | `false`  |
+| `mailTo`                 | `string` | The e-mail address for people apply                        | `true`   |
 | `spaceId`                | `string` | Your Contentful space ID                                   | `true`   |
 | `accessToken`            | `string` | Your Contentful content delivery API access token          | `true`   |
 | `managementToken`        | `string` | Your Contentful personal access                            | `true`   |
 | `environmentId`          | `string` | Your Contentful environment ID. (e.g. `master`)            | `true`   |
-| `mailTo`                 | `string` | The e-mail address for people apply                        | `true`   |
 
 Create your Contentful space, generate all the needed api keys and fill them in.
 

--- a/packages/gatsby-theme-careers/gatsby-config.js
+++ b/packages/gatsby-theme-careers/gatsby-config.js
@@ -3,7 +3,6 @@ module.exports = ({
   title = 'Gatsby Theme Careers',
   spaceId,
   accessToken,
-  googleAnalyticsOptions,
   mailTo,
 } = {}) => ({
   siteMetadata: {

--- a/packages/gatsby-theme-careers/gatsby-config.js
+++ b/packages/gatsby-theme-careers/gatsby-config.js
@@ -3,10 +3,13 @@ module.exports = ({
   title = 'Gatsby Theme Careers',
   spaceId,
   accessToken,
+  googleAnalyticsOptions,
+  mailTo,
 } = {}) => ({
   siteMetadata: {
     title,
     basePath,
+    mailTo,
   },
   plugins: [
     'gatsby-plugin-styled-components',

--- a/packages/gatsby-theme-careers/src/components/ApplyButton.js
+++ b/packages/gatsby-theme-careers/src/components/ApplyButton.js
@@ -1,14 +1,10 @@
 import React from 'react'
 import Button from './Button'
 
-const ApplyButton = ({ mailTo, subject, ...restProps }) => {
+const ApplyButton = ({ mailTo, ...props }) => {
   if (!mailTo) return null
-
-  let mail = `mailTo:${mailTo}`;
-  if (subject) mail += `?subject=${subject}`
-
   return (
-    <Button as='a' title='Send an email' href={mail} {...restProps}>
+    <Button as='a' title='Send an email' href={`mailto:${mailTo}`} {...props}>
       Apply
     </Button>
   )

--- a/packages/gatsby-theme-careers/src/components/ApplyButton.js
+++ b/packages/gatsby-theme-careers/src/components/ApplyButton.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import Button from './Button'
+
+const ApplyButton = ({ mailTo, subject, ...restProps }) => {
+  if (!mailTo) return null
+
+  let mail = `mailTo:${mailTo}`;
+  if (subject) mail += `?subject=${subject}`
+
+  return (
+    <Button as='a' title='Send an email' href={mail} {...restProps}>
+      Apply
+    </Button>
+  )
+}
+
+export default ApplyButton;

--- a/packages/gatsby-theme-careers/src/components/Job.js
+++ b/packages/gatsby-theme-careers/src/components/Job.js
@@ -4,23 +4,33 @@ import { Box, Heading } from 'flokit'
 import Layout from './Layout'
 import TagList from './TagList'
 import Button from './Button'
+import useSiteMetadata from '../hooks/useSiteMetadata'
 
-const Job = ({ job }) => (
-  <Layout>
-    <Box as='header' width={1} marginBottom='5' paddingRight='3'>
-      <Heading as='h1' marginBottom='3' fontSize='8' fontWeight='4'>
-        {job.title}
-      </Heading>
+const Job = ({ job }) => {
+  const { mailTo } = useSiteMetadata()
+  const mail = `mailto:${mailTo}?subject${job.title}`
 
-      <TagList tags={job.tags} />
-    </Box>
+  return (
+    <Layout>
+      <Box as='header' width={1} marginBottom='5' paddingRight='3'>
+        <Heading as='h1' marginBottom='3' fontSize='8' fontWeight='4'>
+          {job.title}
+        </Heading>
 
-    <article>
-      {job.body && documentToReactComponents(job.body.json)}
+        <TagList tags={job.tags} />
+      </Box>
 
-      <Button marginTop='5'>Apply</Button>
-    </article>
-  </Layout>
-)
+      <article>
+        {job.body && documentToReactComponents(job.body.json)}
+
+        {mailTo && (
+          <Button as='a' title='Send an email' href={mail} marginTop='5'>
+            Apply
+          </Button>
+        )}
+      </article>
+    </Layout>
+  )
+}
 
 export default Job

--- a/packages/gatsby-theme-careers/src/components/Job.js
+++ b/packages/gatsby-theme-careers/src/components/Job.js
@@ -2,13 +2,12 @@ import React from 'react'
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
 import { Box, Heading } from 'flokit'
 import Layout from './Layout'
+import ApplyButton from './ApplyButton'
 import TagList from './TagList'
-import Button from './Button'
 import useSiteMetadata from '../hooks/useSiteMetadata'
 
 const Job = ({ job }) => {
   const { mailTo } = useSiteMetadata()
-  const mail = `mailto:${mailTo}?subject${job.title}`
 
   return (
     <Layout>
@@ -23,11 +22,7 @@ const Job = ({ job }) => {
       <article>
         {job.body && documentToReactComponents(job.body.json)}
 
-        {mailTo && (
-          <Button as='a' title='Send an email' href={mail} marginTop='5'>
-            Apply
-          </Button>
-        )}
+        <ApplyButton mailTo={mailTo} subject={job.title} marginTop='5' />
       </article>
     </Layout>
   )

--- a/packages/gatsby-theme-careers/src/components/Job.js
+++ b/packages/gatsby-theme-careers/src/components/Job.js
@@ -22,7 +22,7 @@ const Job = ({ job }) => {
       <article>
         {job.body && documentToReactComponents(job.body.json)}
 
-        <ApplyButton mailTo={mailTo} subject={job.title} marginTop='5' />
+        <ApplyButton mailTo={`${mailTo}?subject=${subject}`} marginTop='5' />
       </article>
     </Layout>
   )

--- a/packages/gatsby-theme-careers/src/hooks/useSiteMetadata.js
+++ b/packages/gatsby-theme-careers/src/hooks/useSiteMetadata.js
@@ -7,6 +7,7 @@ const useSiteMetadata = () => {
         siteMetadata {
           title
           basePath
+          mailTo
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Solve issue #31.
Adds `mailTo` key as theme config.

#### Showroom

![image](https://user-images.githubusercontent.com/1998649/70110468-d3255500-162d-11ea-8e07-440d0c00dccf.png)

#### Where should the reviewer start?

From the key names and Button component inside `Job` component

#### How should this be manually tested?

Get an example job, configure your theme with a valid `mailTo` value. Go to a Job page check if the button is there.
Bad path can be tested leaving the `mailTo` key unfilled on config.

#### Any background context you want to provide?

It uses site metadata hook to get value from config.